### PR TITLE
Add `wink-eng-lite-model` type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,11 @@ declare module 'wink-eng-lite-web-model' {
   export default model;
 }
 
+declare module 'wink-eng-lite-model' {
+  import { model } from 'wink-eng-lite-web-model'; 
+  export default model;
+}
+
 declare module 'wink-nlp' {
   // turn off exporting by default since we don't want to expose internal details
   export {};


### PR DESCRIPTION
# Context

For now the only way to import `wink-eng-lite-model` was using `require`

# What does this PR do?

Adds type definition for `wink-eng-lite-model`. Basically re-exporting the default value
from the existing type for the web version (`wink-eng-lite-web-model`