### PR TITLE
types(*): Move web-eng-lite-web-model typing data to the other package 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wink-nlp",
       "version": "1.8.1",
       "license": "MIT",
       "devDependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,37 +1,45 @@
 // Minimum TypeScript Version: 4.0
 
-declare module 'wink-eng-lite-web-model' {
-  // turn off exporting by default since we don't want to expose internal details
-  export {};
-
-  export type ModelAddons = unknown;
-
-  export interface Model {
-    addons: ModelAddons;
-  }
-
-  const model: Model;
-  export default model;
-}
-
-declare module 'wink-eng-lite-model' {
-  export {};
-
-  export type ModelAddons = unknown;
-
-  export interface Model {
-    addons: ModelAddons;
-  }
-
-  const model: Model;
-  export default model;
-}
-
 declare module 'wink-nlp' {
   // turn off exporting by default since we don't want to expose internal details
-  export {};
+  export { };
 
-  import { Model, ModelAddons } from 'wink-eng-lite-web-model';
+  // these types are internal details of the implementing model
+  type StemAddon = unknown;
+  type LemmatizeAddon = unknown;
+  type ReadabilityStatsAddon = unknown;
+  type WordVectorsAddon = unknown;
+
+  // optional addons that some language models may have
+  export interface ModelAddons {
+    stem?: StemAddon;
+    lemmatize?: LemmatizeAddon;
+    readabilityStats?: ReadabilityStatsAddon;
+    wordVectors?: WordVectorsAddon;
+  }
+
+  // these types are internal details of the implementing model
+  type CoreModel = unknown;
+  type SBDModel = unknown;
+  type POSModel = unknown;
+  type NERModel = unknown;
+  type NEGATIONModel = unknown;
+  type SAModel = unknown;
+  type CERMetaModel = unknown;
+  type FeatureFn = unknown;
+
+  // A language model
+  export interface Model {
+    core: CoreModel;
+    sbd: SBDModel;
+    pos: POSModel;
+    ner: NERModel;
+    negation: NEGATIONModel;
+    sa: SAModel;
+    metaCER: CERMetaModel;
+    featureFn: FeatureFn;
+    addons: ModelAddons;
+  }
 
   // its helpers
 
@@ -294,7 +302,7 @@ declare module 'wink-nlp' {
 
 declare module 'wink-nlp/utilities/bm25-vectorizer' {
   // turn off exporting by default since we don't want to expose internal details
-  export {};
+  export { };
 
   import { Tokens, Document, ItsFunction } from 'wink-nlp';
 
@@ -320,7 +328,7 @@ declare module 'wink-nlp/utilities/bm25-vectorizer' {
 
 declare module 'wink-nlp/utilities/similarity' {
   // turn off exporting by default since we don't want to expose internal details
-  export {};
+  export { };
 
   import { Bow } from 'wink-nlp';
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,5 @@
 import winkNlp, {
+  Model,
   Sentences,
   CustomEntities,
   SelectedCustomEntities,
@@ -14,7 +15,9 @@ import winkNlp, {
   ItsFunction,
   AsFunction,
 } from 'wink-nlp';
-import model from 'wink-eng-lite-web-model';
+
+// dummy model to test with
+const model = ({} as any) as Model;
 
 // $ExpectType WinkMethods
 winkNlp(model);


### PR DESCRIPTION
* Remove the web-eng-lite-web-model declaration and web-eng-lite-model declaration from index.d.ts (these will be moved to the corresponding packages' type declarations)
* Define Model and ModelAddons in greater detail in index.d.ts
* Update test.ts to reflect these changes
