### PR TITLE
Fix type issue with BM25 Vectorizer

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -135,7 +135,7 @@ declare module 'wink-nlp' {
     bow(tf: ModelTermFrequencies): Bow;
     idf(tf: ModelTermFrequencies, idf: ModelInverseDocumentFrequencies): Array<[term: string, frequency: number]>;
     tf(tf: ModelTermFrequencies, idf: ModelInverseDocumentFrequencies): Array<[term: string, frequency: number]>;
-    modelJson(tf: ModelTermFrequencies, idf: ModelInverseDocumentFrequencies): string;
+    modelJSON(tf: ModelTermFrequencies, idf: ModelInverseDocumentFrequencies): string;
   }
 
   // As


### PR DESCRIPTION
One line change that fixes types for out.modelJSON. If you use modelJson it silently fails with no explanation.