### PR TITLE
fix(index.d.ts): update some BM25Vectorizer methods types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -348,11 +348,11 @@ declare module 'wink-nlp/utilities/bm25-vectorizer' {
   }
 
   export interface BM25Vectorizer {
-    learn(tokens: Tokens): void;
+    learn(tokens: string[]): void;
     out<T>(f: ItsFunction<T>): T;
     doc(n: number): Document;
-    vectorOf(tokens: Tokens): number[];
-    bowOf(tokens: Tokens): Bow;
+    vectorOf(tokens: string[]): number[];
+    bowOf(tokens: string[]): Bow;
     config(): BM25VectorizerConfig;
     loadModel(json: string): void;
   }


### PR DESCRIPTION
BM25Vectorizer's .learn() .vectorOf() and .bowOf() accept `string[]` for tokens param, not `Tokens`